### PR TITLE
Precise price filter exceptions and add tests

### DIFF
--- a/pages/models.py
+++ b/pages/models.py
@@ -12,6 +12,7 @@ from wagtail.admin.panels import FieldPanel
 from wagtail.images.blocks import ImageChooserBlock
 from django import forms
 from django.shortcuts import render, redirect
+from decimal import Decimal, InvalidOperation
 
 class PageAccueil(Page):
     template = "pages/accueil.html"
@@ -77,15 +78,19 @@ class CataloguePage(Page):
                 return False
             try:
                 v = Decimal(str(value))
-            except Exception:
+            except (InvalidOperation, ValueError):
                 return False
             good = True
             if pmin:
-                try: good = good and (v >= Decimal(pmin))
-                except Exception: pass
+                try:
+                    good = good and (v >= Decimal(pmin))
+                except (InvalidOperation, ValueError, TypeError):
+                    pass
             if pmax:
-                try: good = good and (v <= Decimal(pmax))
-                except Exception: pass
+                try:
+                    good = good and (v <= Decimal(pmax))
+                except (InvalidOperation, ValueError, TypeError):
+                    pass
             return good
 
         filtered = []

--- a/pages/tests/test_catalogue_page.py
+++ b/pages/tests/test_catalogue_page.py
@@ -1,0 +1,35 @@
+from collections import namedtuple
+from django.test import TestCase, RequestFactory
+from unittest.mock import patch
+
+from pages.models import CataloguePage
+
+
+FakeBlock = namedtuple("FakeBlock", ["block_type", "value"])
+
+
+class CataloguePagePriceFilterTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def _serve(self, page, query_string=""):
+        request = self.factory.get("/", data=None)
+        if query_string:
+            request = self.factory.get(f"/?{query_string}")
+        with patch("pages.models.render") as mocked_render:
+            page.serve(request)
+            # render(request, template, context)
+            ctx = mocked_render.call_args[0][2]
+        return ctx["items"]
+
+    def test_invalid_item_price_excluded(self):
+        page = CataloguePage(title="test", slug="test")
+        page.__dict__["contenu"] = [FakeBlock("item", {"titre": "X", "prix": "oops"})]
+        items = self._serve(page, "min=0")
+        self.assertEqual(items, [])
+
+    def test_invalid_filter_ignored(self):
+        page = CataloguePage(title="test", slug="test")
+        page.__dict__["contenu"] = [FakeBlock("item", {"titre": "X", "prix": 10})]
+        items = self._serve(page, "min=bad&max=also_bad")
+        self.assertEqual(items, page.__dict__["contenu"])


### PR DESCRIPTION
## Summary
- Handle invalid price parsing with `decimal.InvalidOperation` and `ValueError`
- Ignore bad price filters gracefully and ensure items with non-numeric prices are excluded
- Add tests for invalid item prices and malformed filter values

## Testing
- `python manage.py test pages.tests.test_catalogue_page -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68b49e0d92cc8329bc7fb40db4e51bde