### PR TITLE
Add Render host to allowed settings

### DIFF
--- a/site_papa/settings/base.py
+++ b/site_papa/settings/base.py
@@ -16,7 +16,10 @@ import dj_database_url
 
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BASE_DIR = os.path.dirname(PROJECT_DIR)
-CSRF_TRUSTED_ORIGINS = ["https://fkbois.onrender.com"]
+CSRF_TRUSTED_ORIGINS = [
+    "https://fkbois.onrender.com",
+    "https://fbioiss.onrender.com",
+]
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Quick-start development settings - unsuitable for production

--- a/site_papa/settings/dev.py
+++ b/site_papa/settings/dev.py
@@ -7,7 +7,12 @@ DEBUG = True
 SECRET_KEY = "django-insecure-6g(ie^31l=idy19ay!66sq#9*q#1c_jjbk-*pql5(*l=8homao"
 
 # SECURITY WARNING: define the correct hosts in production!
-ALLOWED_HOSTS = ["fkbois.onrender.com", "localhost", "127.0.0.1"]
+ALLOWED_HOSTS = [
+    "fkbois.onrender.com",
+    "fbioiss.onrender.com",
+    "localhost",
+    "127.0.0.1",
+]
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 

--- a/site_papa/settings/production.py
+++ b/site_papa/settings/production.py
@@ -1,4 +1,9 @@
 from .base import *
 
-ALLOWED_HOSTS = ["fkbois.onrender.com", "localhost", "127.0.0.1"]
+ALLOWED_HOSTS = [
+    "fkbois.onrender.com",
+    "fbioiss.onrender.com",
+    "localhost",
+    "127.0.0.1",
+]
 


### PR DESCRIPTION
## Summary
- trust https://fbioiss.onrender.com for CSRF
- allow fbioiss.onrender.com in dev and production hosts

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b540e9b7a883299531ac0bd56b6afc