### PR TITLE
Add accessible labels to catalogue filter inputs

### DIFF
--- a/catalogueMenusereie/pages/templates/pages/catalogue.html
+++ b/catalogueMenusereie/pages/templates/pages/catalogue.html
@@ -15,9 +15,12 @@
 
   <!-- Barre de recherche / filtres -->
   <form method="get" class="catalogue-filter">
-    <input type="text" name="q" placeholder="Rechercher par titre…" value="{{ q }}">
-    <input type="number" step="0.01" name="min" placeholder="Prix min" value="{{ min }}">
-    <input type="number" step="0.01" name="max" placeholder="Prix max" value="{{ max }}">
+    <label for="q">Rechercher par titre</label>
+    <input id="q" type="text" name="q" placeholder="Rechercher par titre…" value="{{ q }}">
+    <label for="min">Prix min</label>
+    <input id="min" type="number" step="0.01" name="min" placeholder="Prix min" value="{{ min }}">
+    <label for="max">Prix max</label>
+    <input id="max" type="number" step="0.01" name="max" placeholder="Prix max" value="{{ max }}">
     <button type="submit" class="button">Filtrer</button>
     {% if q or min or max %}
       <a href="{{ page.url }}" class="button ghost">Réinitialiser</a>

--- a/catalogueMenusereie/site_papa/static/css/catalogue.css
+++ b/catalogueMenusereie/site_papa/static/css/catalogue.css
@@ -23,6 +23,17 @@
   display:flex; gap:10px; flex-wrap:wrap; align-items:center;
   margin: 12px 0 8px;
 }
+.catalogue-filter label{
+  position:absolute;
+  width:1px;
+  height:1px;
+  padding:0;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(0,0,0,0);
+  white-space:nowrap;
+  border:0;
+}
 .catalogue-filter input[type="text"],
 .catalogue-filter input[type="number"]{
   padding:10px 12px; border:1px solid var(--ring); border-radius:10px; background:#fff; font:inherit;


### PR DESCRIPTION
## Summary
- add hidden labels connected to catalogue search filter inputs
- hide labels visually while keeping them accessible for screen readers

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68ba565b556c832989c42f38ecbe0130