### PR TITLE
Add alt text to catalogue and realisation images

### DIFF
--- a/catalogueMenusereie/pages/templates/pages/catalogue.html
+++ b/catalogueMenusereie/pages/templates/pages/catalogue.html
@@ -30,7 +30,7 @@
       <div class="card">
         {% if bloc.image %}
           <div class="card-image">
-            {% image bloc.image fill-600x375 %}
+            {% image bloc.image fill-600x375 alt=bloc.titre %}
           </div>
         {% endif %}
         <div class="card-body">

--- a/catalogueMenusereie/pages/templates/pages/devis.html
+++ b/catalogueMenusereie/pages/templates/pages/devis.html
@@ -1,4 +1,4 @@
-{% extends "pages/base.html" %}0
+{% extends "pages/base.html" %}
 {% load static %}
 {% load wagtailcore_tags wagtailimages_tags %}
 
@@ -22,7 +22,7 @@
       <div class="card-body" style="display:flex; gap:16px; align-items:center;">
         {% if source_image %}
           <div style="width:180px; flex:0 0 180px; border-radius:12px; overflow:hidden;">
-            {% image source_image fill-360x240 %}
+            {% image source_image fill-360x240 alt=form.initial.source_title|default:'Image de la demande de devis' %}
           </div>
         {% endif %}
         <div style="flex:1;">

--- a/catalogueMenusereie/pages/templates/pages/realisation.html
+++ b/catalogueMenusereie/pages/templates/pages/realisation.html
@@ -18,7 +18,11 @@
         <div class="card">
           {% if bloc.galerie %}
             <div class="card-image">
-              {% image bloc.galerie.0 fill-400x300 %}
+              {% if bloc.texte %}
+                {% image bloc.galerie.0 fill-400x300 alt=bloc.texte|striptags|truncatewords:15 %}
+              {% else %}
+                {% image bloc.galerie.0 fill-400x300 alt=page.title %}
+              {% endif %}
             </div>
           {% endif %}
 


### PR DESCRIPTION
## Summary
- Ensure catalogue items render images with alt text from titles
- Add contextual alt text for realisation gallery images
- Provide alt text on devis image preview

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68ba5647da7083299f9a19cb5c3c733b