### PR TITLE
Refactor footer into responsive grid

### DIFF
--- a/catalogueMenusereie/pages/templates/pages/base.html
+++ b/catalogueMenusereie/pages/templates/pages/base.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}FKBois{% endblock %}</title>
   <link rel="stylesheet" href="{% static 'css/site_papa.css' %}">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
   <script defer src="{% static 'js/nav_patch.js' %}?v={% now 'U' %}"></script>
   {% block extra_css %}{% endblock %}
 </head>
@@ -32,10 +33,32 @@
   </main>
 
   <footer class="sp-footer">
-    <div class="container">
-      <p>&copy; {% now "Y" %} — Tous droits réservés.</p>
-      <p><a href="/mentions-legales/">Mentions légales</a></p>
+    <div class="container footer-grid">
+      <div>
+        <h4>Coordonnées</h4>
+        <p>123 Rue des Artisans<br>75000 Paris</p>
+        <p>Tél : 01 23 45 67 89<br>Email : contact@fkbois.fr</p>
+      </div>
+      <div>
+        <h4>Liens rapides</h4>
+        <ul>
+          <li><a href="{% if request.site %}{% pageurl request.site.root_page %}{% else %}/{% endif %}">Accueil</a></li>
+          <li><a href="/catalogue/">Catalogue</a></li>
+          <li><a href="/devis/">Demande de devis</a></li>
+          <li><a href="/contact/">Contact</a></li>
+          <li><a href="/mentions-legales/">Mentions légales</a></li>
+        </ul>
+      </div>
+      <div>
+        <h4>Suivez-nous</h4>
+        <div class="social-icons">
+          <a href="#" aria-label="Facebook"><i class="fab fa-facebook-f"></i></a>
+          <a href="#" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
+          <a href="#" aria-label="Twitter"><i class="fab fa-twitter"></i></a>
+        </div>
+      </div>
     </div>
+    <p class="copyright">&copy; {% now "Y" %} — Tous droits réservés.</p>
   </footer>
 
   {% block extra_js %}{% endblock %}

--- a/catalogueMenusereie/site_papa/static/css/site_papa.css
+++ b/catalogueMenusereie/site_papa/static/css/site_papa.css
@@ -159,6 +159,19 @@ form.form button{margin-top:8px}
 }
 .sp-footer p{margin:0;text-align:center}
 
+.footer-grid{
+  display:grid;
+  gap:16px;
+  grid-template-columns:repeat(auto-fit,minmax(200px,1fr));
+  align-items:start;
+}
+.footer-grid p{text-align:left;margin:0 0 8px}
+.footer-grid ul{list-style:none;margin:0;padding:0}
+.footer-grid a{color:inherit;text-decoration:none}
+.footer-grid a:hover{text-decoration:underline}
+.footer-grid .social-icons{display:flex;gap:12px}
+.footer-grid .social-icons a{font-size:1.5rem}
+
 /* ================= UTILITAIRES ================= */
 .section{padding:28px 0}
 @media (min-width:768px){ .section{padding:46px 0} }

--- a/catalogueMenusereie/site_papa/templates/base.html
+++ b/catalogueMenusereie/site_papa/templates/base.html
@@ -9,6 +9,7 @@
   <title>{% block title %}FKBois{% endblock %}</title>
 
   <link rel="stylesheet" href="{% static 'css/site_papa.css' %}">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
   <script defer src="{% static 'js/nav_patch.js' %}?v={% now 'U' %}"></script>
   {% block extra_css %}{% endblock %}
 </head>
@@ -39,9 +40,32 @@
   </main>
 
   <footer class="sp-footer">
-    <div class="container">
-      <p>&copy; {% now "Y" %} — Tous droits réservés.</p>
+    <div class="container footer-grid">
+      <div>
+        <h4>Coordonnées</h4>
+        <p>123 Rue des Artisans<br>75000 Paris</p>
+        <p>Tél : 01 23 45 67 89<br>Email : contact@fkbois.fr</p>
+      </div>
+      <div>
+        <h4>Liens rapides</h4>
+        <ul>
+          <li><a href="{% if request.site %}{% pageurl request.site.root_page %}{% else %}/{% endif %}">Accueil</a></li>
+          <li><a href="/catalogue/">Catalogue</a></li>
+          <li><a href="/devis/">Demande de devis</a></li>
+          <li><a href="/contact/">Contact</a></li>
+          <li><a href="/mentions-legales/">Mentions légales</a></li>
+        </ul>
+      </div>
+      <div>
+        <h4>Suivez-nous</h4>
+        <div class="social-icons">
+          <a href="#" aria-label="Facebook"><i class="fab fa-facebook-f"></i></a>
+          <a href="#" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
+          <a href="#" aria-label="Twitter"><i class="fab fa-twitter"></i></a>
+        </div>
+      </div>
     </div>
+    <p class="copyright">&copy; {% now "Y" %} — Tous droits réservés.</p>
   </footer>
 
   {% block extra_js %}{% endblock %}


### PR DESCRIPTION
## Summary
- replace footers in base templates with responsive grid showing contact info, quick links, and social icons
- load Font Awesome via CDN for social icons
- style `.footer-grid` for responsive layout in site_papa.css

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68ba56138d788329b83828d765eae219