### PR TITLE
Animate nav links with reduced-motion support

### DIFF
--- a/catalogueMenusereie/site_papa/static/css/site_papa.css
+++ b/catalogueMenusereie/site_papa/static/css/site_papa.css
@@ -89,13 +89,20 @@ body.layout{min-height:100vh;display:flex;flex-direction:column}
 @media (max-width:767px){
   .nav-toggle{display:inline-flex;align-items:center;justify-content:center;margin-left:auto}
   .nav-links{
-    position:absolute;left:0;right:0;top:64px;display:none;flex-direction:column;gap:8px;
+    position:absolute;left:0;right:0;top:64px;flex-direction:column;gap:8px;
     background: linear-gradient(90deg,#f5f2ec 0%, #a1887f 40%, #5d4037 100%);
-    padding:12px 16px;border-bottom:1px solid var(--ring)
+    padding:12px 16px;border-bottom:1px solid var(--ring);
+    transform:translateY(-10px);opacity:0;
+    transition:transform .3s ease, opacity .3s ease
   }
-  .nav-links.open{display:flex}
+  .nav-links.open{
+    transform:translateY(0);
+    opacity:1
+  }
   .nav-links a{width:100%}
 }
+
+@media (prefers-reduced-motion: reduce){ .nav-links{transition:none} }
 
 /* ================= TYPO ================= */
 h1,h2,h3{margin:0 0 .5em;font-weight:900;letter-spacing:.2px}

--- a/catalogueMenusereie/site_papa/static/js/nav.js
+++ b/catalogueMenusereie/site_papa/static/js/nav.js
@@ -1,13 +1,14 @@
 
 (function () {
   const btn = document.querySelector('.nav-toggle');
-  const nav = document.querySelector('.nav');
+  const nav = document.getElementById('nav-links');
   if (!btn || !nav) return;
   btn.addEventListener('click', () => {
     const open = nav.classList.toggle('open');
     btn.setAttribute('aria-expanded', open ? 'true' : 'false');
   });
   nav.querySelectorAll('a').forEach(a => a.addEventListener('click', () => {
-    nav.classList.remove('open'); btn.setAttribute('aria-expanded','false');
+    nav.classList.remove('open');
+    btn.setAttribute('aria-expanded','false');
   }));
 })();


### PR DESCRIPTION
## Summary
- animate mobile nav links with translate and opacity transitions
- respect prefers-reduced-motion preference
- update navigation script to target `nav-links`

## Testing
- no tests run per request

------
https://chatgpt.com/codex/tasks/task_e_68ba56385a8c8329a7d7659a222fec0f